### PR TITLE
fix issues reported by go vet

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"github.com/mohae/utilitybelt/deepcopy"
 	//"golang.org/x/tools/go/types"
+	"errors"
 	"go/token"
 	"go/types"
 	"reflect"
 	"strconv"
 	"strings"
-	"errors"
 )
 
 var ErrGetFromNullObj = errors.New("get attribute from null object")
@@ -417,9 +417,12 @@ func parse_filter(filter string) (lp string, op string, rp string, err error) {
 				str_embrace = true
 			} else {
 				switch stage {
-				case 0: lp = tmp
-				case 1: op = tmp
-				case 2: rp = tmp
+				case 0:
+					lp = tmp
+				case 1:
+					op = tmp
+				case 2:
+					rp = tmp
 				}
 				tmp = ""
 			}
@@ -429,15 +432,18 @@ func parse_filter(filter string) (lp string, op string, rp string, err error) {
 				continue
 			}
 			switch stage {
-			case 0: lp = tmp
-			case 1: op = tmp
-			case 2: rp = tmp
+			case 0:
+				lp = tmp
+			case 1:
+				op = tmp
+			case 2:
+				rp = tmp
 			}
 			tmp = ""
 
 			stage += 1
 			if stage > 2 {
-				return "", "", "", errors.New(fmt.Sprintf("invalid char at %d: `%s`", idx, c))
+				return "", "", "", errors.New(fmt.Sprintf("invalid char at %d: `%c`", idx, c))
 			}
 		default:
 			tmp += string(c)
@@ -448,8 +454,10 @@ func parse_filter(filter string) (lp string, op string, rp string, err error) {
 		case 0:
 			lp = tmp
 			op = "exists"
-		case 1: op = tmp
-		case 2: rp = tmp
+		case 1:
+			op = tmp
+		case 2:
+			rp = tmp
 		}
 		tmp = ""
 	}
@@ -528,11 +536,11 @@ func eval_filter(obj, root interface{}, lp, op, rp string) (res bool, err error)
 
 func isNumber(o interface{}) bool {
 	switch v := o.(type) {
-	case int,int8,int16,int32,int64:
+	case int, int8, int16, int32, int64:
 		return true
-	case uint,uint8,uint16,uint32,uint64:
+	case uint, uint8, uint16, uint32, uint64:
 		return true
-	case float32,float64:
+	case float32, float64:
 		return true
 	case string:
 		_, err := strconv.ParseFloat(v, 64)

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -110,7 +110,7 @@ func Test_jsonpath_JsonPathLookup_1(t *testing.T) {
 func Test_jsonpath_JsonPathLookup_filter(t *testing.T) {
 	res, err := JsonPathLookup(json_data, "$.store.book[?(@.isbn)].isbn")
 	t.Log(err, res)
-	return
+
 	if res_v, ok := res.([]interface{}); ok != true {
 		if res_v[0].(string) != "0-553-21311-3" || res_v[1].(string) != "0-395-19395-8" {
 			t.Errorf("error: %v", res)
@@ -360,7 +360,7 @@ func Test_jsonpath_parse_token(t *testing.T) {
 			if args_v, ok := args.([]int); ok == true {
 				for i, v := range args_v {
 					if v != exp_args.([]int)[i] {
-						t.Errorf("ERROR: different args: [%d], (got)%v != (exp)%v", v, exp_args.([]int)[i])
+						t.Errorf("ERROR: different args: [%d], (got)%v != (exp)%v", i, v, exp_args.([]int)[i])
 						return
 					}
 				}
@@ -850,24 +850,24 @@ var tcase_cmp_any = []map[string]interface{}{
 		"op":   "=~",
 		"exp":  false,
 		"err":  "op should only be <, <=, ==, >= and >",
-	},{
+	}, {
 		"obj1": ifc1,
 		"obj2": ifc1,
 		"op":   "==",
 		"exp":  true,
-		"err": nil,
-	},{
+		"err":  nil,
+	}, {
 		"obj1": ifc2,
 		"obj2": ifc2,
 		"op":   "==",
 		"exp":  true,
-		"err": nil,
-	},{
+		"err":  nil,
+	}, {
 		"obj1": 20,
 		"obj2": "100",
-		"op": ">",
-		"exp": false,
-		"err": nil,
+		"op":   ">",
+		"exp":  false,
+		"err":  nil,
 	},
 }
 
@@ -880,7 +880,7 @@ func Test_jsonpath_cmp_any(t *testing.T) {
 		exp_err := tcase["err"]
 		if exp_err != nil {
 			if err == nil {
-				t.Errorf("idx: error not raised: %v(exp)", idx, exp_err)
+				t.Errorf("idx: %d error not raised: %v(exp)", idx, exp_err)
 				break
 			}
 		} else {
@@ -934,7 +934,6 @@ func Test_jsonpath_string_equal(t *testing.T) {
     },
     "expensive": 10
 }`
-
 
 	var j interface{}
 


### PR DESCRIPTION
This fixes these issues reported by go vet. also ran go fmt

jsonpath.go:440: arg c for printf verb %s of wrong type: rune
jsonpath_test.go:114: unreachable code
jsonpath_test.go:363: missing argument for Errorf("%v"): format reads arg 3, have only 2 args
jsonpath_test.go:883: wrong number of args for format in Errorf call: 1 needed but 2 args