### PR TITLE
Allowing root array access ($[0])

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -71,9 +71,11 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 			}
 		case "idx":
 			//fmt.Println("idx ----------------1")
-			obj, err = get_key(obj, s.key)
-			if err != nil {
-				return nil, err
+			if len(s.key) > 0 {
+				obj, err = get_key(obj, s.key)
+				if err != nil {
+					return nil, err
+				}
 			}
 
 			if len(s.args.([]int)) > 1 {


### PR DESCRIPTION
If the root object is an array, rather then a dict, this allows the path `$[0]`. The code was assuming that there needed to be a key so it was looking for $.""[0] (where the field key in between the quotes was a zero length string)