### PR TITLE
Fixes a problem when root is referenced in filter expression (#19)

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -68,7 +68,11 @@ func (c *Compiled) String() string {
 }
 
 func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
-	var err error
+	var (
+		err  error
+		root = obj
+	)
+
 	for _, s := range c.steps {
 		// "key", "idx"
 		switch s.op {
@@ -128,7 +132,7 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 			if err != nil {
 				return nil, err
 			}
-			obj, err = get_filtered(obj, obj, s.args.(string))
+			obj, err = get_filtered(obj, root, s.args.(string))
 			if err != nil {
 				return nil, err
 			}

--- a/jsonpath_test.go
+++ b/jsonpath_test.go
@@ -134,11 +134,47 @@ func Test_jsonpath_JsonPathLookup_filter(t *testing.T) {
 
 	res, err = JsonPathLookup(json_data, "$.store.book[?(@.price > 10)]")
 	t.Log(err, res)
+	if res_v, ok := res.([]interface{}); !ok {
+		t.Errorf("expected: []interface{}, received: %v", res)
+	} else {
+		if len(res_v) != 2 {
+			t.Errorf("length of result should be 2, but actual length is %d: %v", len(res_v), res_v)
+		} else {
+			prices := []interface{}{res_v[0].(map[string]interface{})["price"], res_v[1].(map[string]interface{})["price"]}
+			if prices[0] != 12.99 || prices[1] != 22.99 {
+				t.Errorf("expected book prices: [12.99, 22.99] but received: %v, result: %v", prices, res_v)
+			}
+		}
+	}
 
 	res, err = JsonPathLookup(json_data, "$.store.book[?(@.price > $.expensive)].price")
 	t.Log(err, res)
+	if res_v, ok := res.([]interface{}); ok != true {
+		t.Errorf("expected: []interface{}, received: %v", res)
+	} else {
+		if len(res_v) != 2 {
+			t.Errorf("length of result should be 2, but actual length is %d: %v", len(res_v), res_v)
+		} else {
+			if res_v[0].(float64) != 12.99 || res_v[1].(float64) != 22.99 {
+				t.Errorf("expected result: [12.99, 22.99] but received: %v", res_v)
+			}
+		}
+	}
+
 	res, err = JsonPathLookup(json_data, "$.store.book[?(@.price < $.expensive)].price")
 	t.Log(err, res)
+	if res_v, ok := res.([]interface{}); ok != true {
+		t.Errorf("expected: []Goods, received: %v", res)
+	} else {
+		if len(res_v) != 2 {
+			t.Errorf("length of result should be 2, but actual length is %d: %v", len(res_v), res_v)
+		} else {
+			prices := []float64{res_v[0].(float64), res_v[1].(float64)}
+			if prices[0] != 8.95 || prices[1] != 8.99 {
+				t.Errorf("expected result: [8.95, 8.99] but received: %v", prices)
+			}
+		}
+	}
 }
 
 func Test_jsonpath_authors_of_all_books(t *testing.T) {


### PR DESCRIPTION
This PR fixes problem when root is referenced($) in a filter expression and the evaluated value was the current object(@) instead of the root.

After this fix the example referenced in #19 issue is now working properly.