### PR TITLE
skipping error when field is missing

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -465,7 +465,11 @@ func get_filtered(obj, root interface{}, filter string) ([]interface{}, error) {
 				tmp := reflect.ValueOf(obj).Index(i).Interface()
 				ok, err := eval_reg_filter(tmp, root, lp, pat)
 				if err != nil {
-					return nil, err
+					if strings.ContainsAny(err.Error(), "key error: & not found in object") {
+						continue
+					} else {
+						return nil, err
+					}
 				}
 				if ok == true {
 					res = append(res, tmp)


### PR DESCRIPTION
IMO, when the field is missing in the slice, instead of erring out, ignoring that and continuing onto the next index/element is more relevant I feel.