### PR TITLE
fix panic:obj is nil

### DIFF
--- a/jsonpath.go
+++ b/jsonpath.go
@@ -85,6 +85,9 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 					return nil, err
 				}
 			}
+			if obj == nil {
+				return nil, fmt.Errorf("obj is nil")
+			}
 
 			if len(s.args.([]int)) > 1 {
 				res := []interface{}{}
@@ -114,6 +117,9 @@ func (c *Compiled) Lookup(obj interface{}) (interface{}, error) {
 				if err != nil {
 					return nil, err
 				}
+			}
+			if obj == nil {
+				return nil, fmt.Errorf("obj is nil")
 			}
 			if argsv, ok := s.args.([2]interface{}); ok == true {
 				obj, err = get_range(obj, argsv[0], argsv[1])


### PR DESCRIPTION
修复panic：当obj有值时为数组，无值时为nil时，通过数组方式提取会触发panic
例：
ans = {
"a": nil
}
通过a[0,1]或者a[*]提取时，会触发panic